### PR TITLE
Pin full length commit SHA for 3rd party actions.

### DIFF
--- a/.github/workflows/lint-checker-php.yml
+++ b/.github/workflows/lint-checker-php.yml
@@ -21,16 +21,16 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
         with:
           php-version: '7.3'
           coverage: none
           tools: composer, cs2pr
 
-      - uses: technote-space/get-diff-action@v6
+      - uses: technote-space/get-diff-action@f27caffdd0fb9b13f4fc191c016bb4e0632844af # v6.1.2
         with:
           PATTERNS: |
             **/*.php
@@ -42,7 +42,7 @@ jobs:
         if: "!! env.GIT_DIFF"
 
       - name: Cache Composer vendor directory
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -22,7 +22,7 @@ jobs:
         run: echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
 
       - name: Repository Dispatch
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           token: ${{ secrets.WEBHOOK_TOKEN }}
           repository: newfold-labs/satis


### PR DESCRIPTION
## Proposed changes

This implements the [recommendation to pin full length commit SHAs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) instead of versions or branches when using 3rd-party GitHub Actions to protect from supply chain attacks.

This has been happening more often recently, with a number of popular actions having all of their tags updated with a buried vulnerability.

While the new notation is more verbose, a bit ugly, and requires every update to be applied manually, we can rely on Dependabot to handle that for us to make it more manageable.

Recent examples

Examples of actions being exploited in the wild:
- [changed-files](https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/)
- [reviewdog's action library](https://www.stepsecurity.io/blog/reviewdog-github-actions-are-compromised)

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update
- [X] Build/Test Tooling update

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [X] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

GitHub is [looking into providing immutable releases](https://github.com/features/preview/immutable-actions) for actions (which would allow versions to be used again), and this is currently in the [Q3 2025 roadmap](https://github.com/github/roadmap/issues/592). But we should use full SHA values until then.

See also https://github.com/newfold-labs/workflows/pull/22.