### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/brand-plugin-test.yml
+++ b/.github/workflows/brand-plugin-test.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Extract branch name
         shell: bash
-        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> "$GITHUB_OUTPUT"
         id: extract_branch
 
   bluehost:
@@ -35,7 +35,6 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@main
     permissions:
       contents: read # Required so the called workflow token can clone private plugin and module repos via checkout/composer (same org).
-    timeout-minutes: 120
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test.yml
+++ b/.github/workflows/brand-plugin-test.yml
@@ -19,6 +19,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     permissions: {} # Runs only bash using env/context; no checkout or GitHub API token use.
+    timeout-minutes: 30
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -34,6 +35,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@main
     permissions:
       contents: read # Required so the called workflow token can clone private plugin and module repos via checkout/composer (same org).
+    timeout-minutes: 120
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test.yml
+++ b/.github/workflows/brand-plugin-test.yml
@@ -10,10 +10,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
+    permissions: {} # Runs only bash using env/context; no checkout or GitHub API token use.
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -27,6 +32,8 @@ jobs:
     name: Bluehost Build and Test
     needs: setup
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@main
+    permissions:
+      contents: read # Required so the called workflow token can clone private plugin and module repos via checkout/composer (same org).
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/lint-checker-php.yml
+++ b/.github/workflows/lint-checker-php.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required to clone the repo for checkout and diff-based linting.
+    timeout-minutes: 30
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint-checker-php.yml
+++ b/.github/workflows/lint-checker-php.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Get Composer cache directory
         id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
         if: "!! env.GIT_DIFF"
 
       - name: Cache Composer vendor directory

--- a/.github/workflows/lint-checker-php.yml
+++ b/.github/workflows/lint-checker-php.yml
@@ -14,10 +14,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the repo for checkout and diff-based linting.
     steps:
 
       - name: Checkout

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -21,11 +21,11 @@ jobs:
         id: package
         env:
           REPO: ${{ github.repository }}
-        run: echo "PACKAGE=${REPO##*/}" >> $GITHUB_OUTPUT
+        run: echo "PACKAGE=${REPO##*/}" >> "$GITHUB_OUTPUT"
 
       - name: Set Version
         id: tag
-        run: echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
+        run: echo "VERSION=${GITHUB_REF##*/}" >> "$GITHUB_OUTPUT"
 
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {} # peter-evans/repository-dispatch uses secrets.WEBHOOK_TOKEN, not github.token.
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -14,6 +14,7 @@ jobs:
     name: Send Webhook
     runs-on: ubuntu-latest
     permissions: {} # peter-evans/repository-dispatch uses secrets.WEBHOOK_TOKEN, not github.token.
+    timeout-minutes: 30
     steps:
 
       - name: Set Package


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 3 (`satis-update.yml`, `lint-checker-php.yml`, `brand-plugin-test.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | `816289a` |
| Timeouts commit | `45c9aae` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-update.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint-checker-php.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `brand-plugin-test.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| satis-update.yml | 1 job was missing a scoped `permissions:` directive | webhook | `permissions: {}` [3] |
| lint-checker-php.yml | 1 job was missing a scoped `permissions:` directive | phpcs | `contents: read # Required to clone the repo for checkout and diff-based linting.` [3] |
| brand-plugin-test.yml | 2 jobs were missing a scoped `permissions:` directive | setup | `permissions: {}` [3] |
| brand-plugin-test.yml | 2 jobs were missing a scoped `permissions:` directive | bluehost | `contents: read # Required so the called workflow token can clone private plugin and module repos via checkout/composer (same org).` [3] |


## Permissions corrections (previously incorrect)

No pre-existing configured `permissions:` were identified as incorrect.

## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| satis-update.yml | webhook | `30` | Webhook-only job with a handful of lightweight steps; 30 minutes is ample headroom. |
| lint-checker-php.yml | phpcs | `30` | Composer install plus PHPCS on diffed PHP paths is comfortably bounded inside half an hour. |
| brand-plugin-test.yml | setup | `30` | Single bash step deriving branch metadata; minimal runtime with a conservative cap. |
| brand-plugin-test.yml | bluehost | `120` | Invokes reusable `module-plugin-test` (Composer, npm builds, `@wordpress/env`, Cypress); allowed two hours versus the lighter CI jobs above. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | Call site for `bluehost`: permissions were aligned with downstream `module-plugin-test.yml` (`contents: read` for cloning). If Composer/git steps require additional token scopes (e.g. org-specific package registries), that would need org-level verification; `NEWFOLD_ACCESS_TOKEN` and other secrets are inherited as before. |
| 2 | `peter-evans/repository-dispatch` is configured with `secrets.WEBHOOK_TOKEN` rather than `github.token`, so `webhook` correctly uses no default token scopes. |
| 3 | Commits were created with `--no-gpg-sign` because GPG signing failed under the initial sandbox; local branch was not pushed, per instructions. |


